### PR TITLE
Fix issue with branch naming convention in the CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 # Supported operating systems: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 jobs:


### PR DESCRIPTION
### Quick Summary
<!-- Choose one-->
- [ ] pyuvs addition
- [ ] pyuvs bug fix
- [ ] Data product addition
- [ ] Data product bug fix
- [ ] Documentation fix
- [x] Other

### Related issues
<!-- Post the issue #, discussion, etc. if applicable. -->
None

### Extended summary
<!-- Describe what will be changed if this request is approved. -->
This will change the CI to run on pushes and pull requests from master, not main (my mistake).
